### PR TITLE
Add testing infrastructure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     ggplot2,
     TTR
 Suggests: 
-    recipes
+    recipes,
+    testthat
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(dorem)
+
+test_check("dorem")

--- a/tests/testthat/test-banister-model.R
+++ b/tests/testthat/test-banister-model.R
@@ -1,0 +1,18 @@
+test_that("banister model prediction works as expected", {
+
+  test_model <- list(coefs=list(intercept=496,
+				w=list(PTE_gain=.07, PTE_tau=60,
+				       NTE_gain=.27, NTE_tau=13)),
+                     control=list(link_func=function(x) x))
+
+
+  predictors_df <- data.frame(w = c(0, 0, 0))
+  pred_zeros <- banister_predict(test_model, predictors_df)
+
+  expect_equal(pred_zeros, rep(496, 3))
+
+  predictors_df <- data.frame(w = c(1, 0, 0))
+  pred_unit <- banister_predict(test_model, predictors_df)
+
+  expect_equal(pred_unit[1], 496)  # time 0: no fitness or fatigue accumulated
+})


### PR DESCRIPTION
Hello!

I had brief correspondence with Mladen on Twitter and this pull request is meant to be an entry point into collaboration. I'm interested in dose-response in weightlifting and effects that accumulate over time in general, and it's good to have a project! I've got relatively thick skin when it comes to coding, so if you don't like my ideas, I won't lose sleep over closed issues and PRs. Hopefully we can plan them ahead of time.

The rationale behind this pull request is that every package can benefit from a testing suite. I used the [usethis](https://usethis.r-lib.org/reference/index.html) package to create testing infrastructure with `use_testthat()`, and created the first test with `use_test('banister-model')`. Tests can be run with `devtools::test()`.

My second test case is failing, so your input would be appreciated. Starting at line 14 of `tests/testthat/test-banister-model.R`, this test creates a situation where a unit impulse occurs at the first time point. Though it's indexed as 1, I'm interpreting this as time 0 where no fitness or fatigue effects have had time to accumulate. Thus, the test wants to see the model intercept in the first position, but what it's finding is the intercept plus the net training effect of the first session. 

Looking at the equation:
![image](https://user-images.githubusercontent.com/2700556/89722325-f5862400-d9ad-11ea-8ff4-73b0881c59cb.png)
it looks like there's an initial performance, `p(0)`, and initial training impulse, `w(0)`, and that these two are independent of each other. It  also wouldn't make sense to sum from s = 0 to s = -1, so I think it's implied that the prediction equation starts at t = 1, affected by only the first training impulse at s = 0. Restated, I think there has to be a lag between training impulse and its effect on performance, and I believe that this test shows the lag isn't there.

If you agree, up to you whether to merge this PR now and create a separate issue, or I could work on the function in this PR.

- Ben